### PR TITLE
Generate version 4 databases

### DIFF
--- a/generate_version_4.py
+++ b/generate_version_4.py
@@ -1,0 +1,212 @@
+"""
+Generate a version 4 database file for qcodes' test suite to consume.
+"""
+
+import os
+import numpy as np
+
+# NB: it's important that we do not import anything from qcodes before we
+# do the git magic (which we do below), hence the relative import here
+import utils as utils
+
+
+def generate_empty_DB_file():
+    """
+    Generate an empty DB file with no runs
+    """
+
+    import qcodes.dataset.sqlite_base as sqlite_base
+
+    v4fixturepath = os.path.join(utils.fixturepath, 'version4')
+    os.makedirs(v4fixturepath, exist_ok=True)
+    path = os.path.join(v4fixturepath, 'empty.db')
+
+    if os.path.exists(path):
+        os.remove(path)
+
+    sqlite_base.connect(path)
+
+
+def generate_DB_file_with_runs_but_no_snapshots():
+    """
+    Generate a .db-file with a handful of runs without snapshots
+    """
+
+    # This function will run often on CI and re-generate the .db-files
+    # That should ideally be a deterministic action
+    # (although this hopefully plays no role)
+    np.random.seed(0)
+
+    v4fixturepath = os.path.join(utils.fixturepath, 'version4')
+    os.makedirs(v4fixturepath, exist_ok=True)
+    path = os.path.join(v4fixturepath, 'with_runs_but_no_snapshots.db')
+
+    if os.path.exists(path):
+        os.remove(path)
+
+    from qcodes.dataset.sqlite_base import connect, is_column_in_table
+    from qcodes.dataset.measurements import Measurement
+    from qcodes.dataset.experiment_container import Experiment
+    from qcodes import Parameter, Station
+
+    connect(path)
+
+    exp = Experiment(path_to_db=path,
+                     name='experiment_1',
+                     sample_name='no_sample_1')
+    conn = exp.conn
+
+    assert not is_column_in_table(conn, 'runs', 'snapshot')
+
+    # Now make some parameters to use in measurements
+    params = []
+    for n in range(4):
+        params.append(Parameter(f'p{n}', label=f'Parameter {n}',
+                                unit=f'unit {n}', set_cmd=None, get_cmd=None))
+
+    assert Station.default is None
+
+    # Set up an experiment
+
+    meas = Measurement(exp)
+    meas.register_parameter(params[0])
+    meas.register_parameter(params[1])
+    meas.register_parameter(params[2], basis=(params[1],))
+    meas.register_parameter(params[3], setpoints=(params[1], params[2]))
+
+    # Make a number of identical runs
+
+    for _ in range(4):
+
+        with meas.run() as datasaver:
+
+            for x in np.random.rand(4):
+                for y in np.random.rand(4):
+                    z = np.random.rand()
+                    datasaver.add_result((params[1], x),
+                                         (params[2], y),
+                                         (params[3], z))
+
+    assert not is_column_in_table(conn, 'runs', 'snapshot')
+
+
+def generate_DB_file_with_runs_and_snapshots():
+    """
+    Generate a .db-file with a handful of runs some of which have snapshots.
+
+    Generated runs:
+        #1: run with a snapshot that has some content
+        #2: run with a snapshot of an empty station
+        #3: run without a snapshot
+    """
+    v4fixturepath = os.path.join(utils.fixturepath, 'version4')
+    os.makedirs(v4fixturepath, exist_ok=True)
+    path = os.path.join(v4fixturepath, 'with_runs_and_snapshots.db')
+
+    if os.path.exists(path):
+        os.remove(path)
+
+    from qcodes.dataset.sqlite_base import is_column_in_table
+    from qcodes.dataset.measurements import Measurement
+    from qcodes.dataset.experiment_container import Experiment
+    from qcodes import Parameter, Station
+    from qcodes.dataset.descriptions import RunDescriber
+    from qcodes.dataset.dependencies import InterDependencies
+
+    exp = Experiment(path_to_db=path,
+                     name='experiment_1',
+                     sample_name='no_sample_1')
+    conn = exp.conn
+
+    # Now make some parameters to use in measurements
+    params = []
+    for n in range(4):
+        params.append(Parameter(f'p{n}', label=f'Parameter {n}',
+                                unit=f'unit {n}', set_cmd=None, get_cmd=None))
+
+    # We are going to make 3 runs
+    run_ids = []
+
+    # Make a run with a snapshot with some content
+
+    full_station = Station(*params[0:1], default=False)
+    assert Station.default is None
+
+    meas = Measurement(exp, full_station)
+    meas.register_parameter(params[0])
+    meas.register_parameter(params[1])
+    meas.register_parameter(params[2], basis=(params[1],))
+    meas.register_parameter(params[3], setpoints=(params[1], params[2]))
+
+    with meas.run() as datasaver:
+
+        for x in np.random.rand(4):
+            for y in np.random.rand(4):
+                z = np.random.rand()
+                datasaver.add_result((params[1], x),
+                                     (params[2], y),
+                                     (params[3], z))
+
+    run_ids.append(datasaver.run_id)
+
+    # Make a run with a snapshot of empty station
+
+    empty_station = Station(default=False)
+    assert Station.default is None
+
+    meas = Measurement(exp, empty_station)
+    meas.register_parameter(params[0])
+    meas.register_parameter(params[1])
+    meas.register_parameter(params[2])
+    meas.register_parameter(params[3], setpoints=(params[1], params[2]))
+
+    with meas.run() as datasaver:
+
+        for x in np.random.rand(4):
+            for y in np.random.rand(4):
+                z = np.random.rand()
+                datasaver.add_result((params[1], x),
+                                     (params[2], y),
+                                     (params[3], z))
+
+    run_ids.append(datasaver.run_id)
+
+    # Make a run without a snapshot (i.e. station is None)
+
+    assert Station.default is None
+
+    meas = Measurement(exp)
+    meas.register_parameter(params[0])
+    meas.register_parameter(params[1])
+    meas.register_parameter(params[2], basis=(params[1],))
+    meas.register_parameter(params[3], setpoints=(params[1], params[2]))
+
+    with meas.run() as datasaver:
+
+        for x in np.random.rand(4):
+            for y in np.random.rand(4):
+                z = np.random.rand()
+                datasaver.add_result((params[1], x),
+                                     (params[2], y),
+                                     (params[3], z))
+
+    run_ids.append(datasaver.run_id)
+
+    # Check correctness of run_id's
+
+    assert [1, 2, 3] == run_ids, 'Run ids of generated runs are not as ' \
+                                 'expected after generating runs #1-3'
+
+    # Ensure snapshot column
+
+    assert is_column_in_table(conn, 'runs', 'snapshot')
+
+
+if __name__ == '__main__':
+
+    gens = (generate_empty_DB_file,
+            generate_DB_file_with_runs_but_no_snapshots,
+            generate_DB_file_with_runs_and_snapshots)
+
+    # pylint: disable=E1101
+    utils.checkout_to_old_version_and_run_generators(version='4a', gens=gens)

--- a/generate_version_4.py
+++ b/generate_version_4.py
@@ -209,4 +209,4 @@ if __name__ == '__main__':
             generate_DB_file_with_runs_and_snapshots)
 
     # pylint: disable=E1101
-    utils.checkout_to_old_version_and_run_generators(version='4a', gens=gens)
+    utils.checkout_to_old_version_and_run_generators(version=4, gens=gens)

--- a/utils.py
+++ b/utils.py
@@ -21,9 +21,9 @@ from git import Repo
 #   come from the previous "upgrade from 2 to 3"; this upgrade basically
 #   re-does the "upgrade from 2 to 3" but without those bugs.
 #
-# Fix for version 4 (the fix is called 4a): is actually version 4 again,
-#   but has a separate upgrader to fix bugs in how the run_description was
-#   written
+# Fix for version 4: a bug was introduced that accidentally wrote an 
+#   invalid runs description. The bug is reproduced by version 4a.
+#   The commit of version 4 does not have the bug.
 #
 # Upgrade from 4 to 5: snapshot column is made always present
 #   in the runs table

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,5 @@
 # General utilities for the database generation and loading scheme
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Tuple, Union
 import importlib
 from contextlib import contextmanager
 import os
@@ -8,22 +8,25 @@ from git import Repo
 
 # A brief overview of what each version introduces:
 #
-# Version 0: the original table schema, runs, experiments, layouts,
-# dependencies, result-tables
+# Inception of version 0: the original table schema, runs, experiments,
+# layouts, dependencies, result-tables
 #
-# Version 1: a GUID column is added to the runs table
+# Upgrade from 0 to 1: a GUID column is added to the runs table
 #
-# Version 2: indices are added to runs; GUID and exp_id
+# Upgrade from 1 to 2: indices are added to runs; GUID and exp_id
 #
+# Upgrade from 2 to 3: run_description column is added to the runs table
 #
 # Upgrade from 3 to 4: fixes two bugs in the inferred annotation which
 #   come from the previous "upgrade from 2 to 3" by redoing that
 #   "upgrade from 2 to 3" without those bugs.
 #
-# Version 4a: is actually version 3 again, but has a separate upgrader
-#   to fix bugs in how the run_description was written
+# Fix for version 4 (the fix is called 4a): is actually version 4 again,
+#   but has a separate upgrader to fix bugs in how the run_description was
+#   written
 #
-# Version 4: snapshot column is made always present in the runs table
+# Upgrade from 4 to 5: snapshot column is made always present
+#   in the runs table
 #
 # The version '4a' hash represents a merge commit that accidentally broke the
 # way run_descriptions were written. Since a fix was quickly implemented, we

--- a/utils.py
+++ b/utils.py
@@ -15,7 +15,10 @@ from git import Repo
 #
 # Version 2: indices are added to runs; GUID and exp_id
 #
-# Version 3: run_description column is added to the runs table
+#
+# Upgrade from 3 to 4: fixes two bugs in the inferred annotation which
+#   come from the previous "upgrade from 2 to 3" by redoing that
+#   "upgrade from 2 to 3" without those bugs.
 #
 # Version 4a: is actually version 3 again, but has a separate upgrader
 #   to fix bugs in how the run_description was written

--- a/utils.py
+++ b/utils.py
@@ -20,6 +20,8 @@ from git import Repo
 # Version 4a: is actually version 3 again, but has a separate upgrader
 #   to fix bugs in how the run_description was written
 #
+# Version 4: snapshot column is made always present in the runs table
+#
 # The version '4a' hash represents a merge commit that accidentally broke the
 # way run_descriptions were written. Since a fix was quickly implemented, we
 # do not promote this to a schema upgrade, but leave it as a fix function.
@@ -34,7 +36,8 @@ GIT_HASHES: Dict[Union[int, str], str] = {
     1: '056d59627e22fa3ca7aad4c265e9897c343f79cf',
     2: '5202255924542dad6841dfe3d941a7f80c43956c',
     3: '17436006caceaeb42ea66e5cbaca40bb4c54306a',
-    '4a': '6b8f4d1940215a8cefc5f4c399c6aaaeee082d54'}
+    '4a': '6b8f4d1940215a8cefc5f4c399c6aaaeee082d54',
+    4: '57ad8711d158f68ecf101006bb8f2072aee157ab'}
 
 __initpath = os.path.realpath(importlib.util.find_spec('qcodes').origin)
 gitrepopath = os.sep.join(__initpath.split(os.path.sep)[:-2])

--- a/utils.py
+++ b/utils.py
@@ -18,8 +18,8 @@ from git import Repo
 # Upgrade from 2 to 3: run_description column is added to the runs table
 #
 # Upgrade from 3 to 4: fixes two bugs in the inferred annotation which
-#   come from the previous "upgrade from 2 to 3" by redoing that
-#   "upgrade from 2 to 3" without those bugs.
+#   come from the previous "upgrade from 2 to 3"; this upgrade basically
+#   re-does the "upgrade from 2 to 3" but without those bugs.
 #
 # Fix for version 4 (the fix is called 4a): is actually version 4 again,
 #   but has a separate upgrader to fix bugs in how the run_description was

--- a/utils.py
+++ b/utils.py
@@ -17,7 +17,7 @@ from git import Repo
 #
 # Version 3: run_description column is added to the runs table
 #
-# Version 4: is actually version 3 again, but has a separate upgrader
+# Version 4a: is actually version 3 again, but has a separate upgrader
 #   to fix bugs in how the run_description was written
 #
 # The version '4a' hash represents a merge commit that accidentally broke the


### PR DESCRIPTION
We do this because we move to version 5 databases where snapshot column __always__ exists in the runs table.

Also add missing description of version 4, and reword the descriptions to avoid confusion.